### PR TITLE
docs: add SaaS redesign and NestJS backend proposal

### DIFF
--- a/.planning/SAAS_BACKEND_NEST_PROPOSAL.md
+++ b/.planning/SAAS_BACKEND_NEST_PROPOSAL.md
@@ -1,0 +1,235 @@
+# SAAS_BACKEND_NEST_PROPOSAL
+
+## Objetivo
+
+Introducir un backend en NestJS para que Pichasafio deje de depender de lógica de negocio dispersa en el frontend y pueda evolucionar a SaaS sin abandonar Supabase como base de datos.
+
+---
+
+## Arquitectura objetivo
+
+## Frontend
+- React + Vite
+- consume API propia de NestJS
+- solo usa Supabase Auth cliente donde convenga la sesión inicial
+
+## Backend
+- NestJS
+- capa de negocio principal
+- validación de reglas
+- control de acceso premium
+- recomendación de programas
+- endpoints de progreso, contenido y suscripción
+
+## Infraestructura de datos
+- Supabase PostgreSQL
+- Supabase Auth
+- Supabase Storage
+
+---
+
+## Principio clave
+
+**Supabase sigue siendo la base de datos, pero NestJS se vuelve el backend real del producto.**
+
+Eso permite:
+- centralizar lógica
+- evitar lógica sensible en cliente
+- controlar monetización
+- preparar app mobile/API pública futura
+- escalar hacia más módulos sin caos
+
+---
+
+## Propuesta de estructura técnica
+
+## Monorepo recomendado
+
+```text
+/apps
+  /web        -> frontend actual React/Vite
+  /api        -> nuevo backend NestJS
+/packages
+  /shared     -> tipos, contratos, utils comunes
+```
+
+Si no quieres monorepo de una vez, al menos:
+
+```text
+/pichasafio        -> frontend actual
+/pichasafio-api    -> nuevo backend NestJS
+```
+
+Mi recomendación: monorepo simple si se puede.
+
+---
+
+## Módulos iniciales de NestJS
+
+## 1. AuthModule
+Responsabilidad:
+- validar JWT de Supabase
+- resolver usuario autenticado
+- guards
+
+## 2. UsersModule
+Responsabilidad:
+- perfil
+- onboarding
+- evaluación inicial
+- preferencias
+
+## 3. ContentModule
+Responsabilidad:
+- ejercicios
+- assets
+- categorías
+- objetivos
+- dificultad
+
+## 4. RoutinesModule
+Responsabilidad:
+- rutinas
+- pasos
+- filtros
+- asignación
+
+## 5. ProgramsModule
+Responsabilidad:
+- programas
+- días
+- progreso por programa
+- challenge de 30 días migrado
+
+## 6. ProgressModule
+Responsabilidad:
+- registrar sesiones
+- cumplimiento diario
+- streaks
+- historial
+
+## 7. BillingModule
+Responsabilidad:
+- planes
+- suscripciones
+- entitlements
+- premium access
+
+## 8. CommunityModule (después)
+Responsabilidad:
+- feed
+- comentarios
+- likes
+- rewards
+- leaderboard
+
+---
+
+## Conexión con Supabase
+
+## Opción recomendada
+NestJS se conecta directamente a Postgres usando ORM.
+
+### Recomendación ORM
+- **Prisma**
+
+### ¿Por qué?
+- tipado fuerte
+- migraciones más ordenadas
+- mejor DX para reorganizar dominio
+- ideal si vienes de rediseño estructural
+
+NestJS también puede usar el SDK de Supabase en casos puntuales para:
+- verificar auth tokens
+- firmar URLs de Storage
+- manejar algunos flujos específicos
+
+Pero el acceso principal al modelo de negocio debería ser por ORM al Postgres.
+
+---
+
+## Auth strategy
+
+## Mantener
+- Supabase Auth
+
+## Agregar
+- NestJS guard que valide el JWT emitido por Supabase
+- decorador `CurrentUser`
+- capa de autorización por plan/entitlements
+
+### Resultado
+El usuario se loguea como hoy, pero el backend NestJS toma control de la lógica protegida.
+
+---
+
+## Storage strategy
+
+Seguir usando Supabase Storage o Cloudinary según tipo de asset.
+
+### Recomendación
+- videos premium y contenido estructurado: preferir estrategia clara única
+- si Cloudinary ya está funcionando bien para media pública, puede quedarse
+- si quieres simplificar operación, centralizar más en Supabase Storage
+
+No mezclar arbitrariamente ambos sin una política clara.
+
+---
+
+## Fases de implementación backend
+
+## Fase 1
+Crear backend base:
+- NestJS app
+- Prisma
+- conexión a Supabase Postgres
+- validación de JWT Supabase
+- módulos base `Auth`, `Users`, `Programs`, `Progress`
+
+## Fase 2
+Modelar core nuevo:
+- exercises
+- routines
+- programs
+- user_programs
+- user_sessions
+
+## Fase 3
+Migrar challenge actual de 30 días al nuevo dominio.
+
+## Fase 4
+Mover frontend a consumir NestJS en:
+- perfil
+- programas
+- progreso
+- contenido
+
+## Fase 5
+Agregar billing/entitlements.
+
+---
+
+## Qué NO haría
+- no dejaría toda la lógica premium en el frontend
+- no seguiría metiendo reglas en `challengeService.ts`
+- no construiría primero comunidad o más gamificación
+- no intentaría rehacer todo el frontend antes de tener backend y dominio claros
+
+---
+
+## Primera meta técnica realista
+
+La primera meta correcta es:
+
+**poner a correr `apps/api` con NestJS + Prisma + Supabase Postgres + auth guard de Supabase**
+
+Y luego implementar los primeros endpoints:
+- `GET /me`
+- `PATCH /me/profile`
+- `GET /programs`
+- `GET /programs/:id`
+- `POST /programs/:id/start`
+- `POST /sessions/complete`
+- `GET /progress/summary`
+
+Con eso ya empiezas a sacar negocio del frontend.

--- a/.planning/SAAS_DOMAIN_MAP.md
+++ b/.planning/SAAS_DOMAIN_MAP.md
@@ -1,0 +1,188 @@
+# SAAS_DOMAIN_MAP
+
+## Centro del dominio
+
+El nuevo centro del producto debe ser:
+
+`User + Exercise + Routine + Program + Session + Subscription`
+
+No debe ser:
+- el reto hardcoded de 30 días
+- el leaderboard
+- el feed
+- videos sueltos
+
+---
+
+## Bounded contexts
+
+## A. Identity
+### Responsabilidad
+Gestionar autenticación, perfil y acceso.
+
+### Entidades
+- `User`
+- `UserProfile`
+- `UserAssessment`
+- `UserGoal`
+
+### Notas
+- Auth puede seguir viviendo en Supabase Auth.
+- El backend NestJS debe centralizar lectura/escritura de negocio y validaciones.
+
+---
+
+## B. Content Engine
+### Responsabilidad
+Modelar el contenido propio reusable.
+
+### Entidades
+- `Exercise`
+- `ExerciseVariant`
+- `Instruction`
+- `Contraindication`
+- `MediaAsset`
+- `Category`
+- `Goal`
+- `DifficultyLevel`
+
+### Notas
+Cada ejercicio debe ser reusable en múltiples rutinas y programas.
+
+---
+
+## C. Routine Engine
+### Responsabilidad
+Definir combinaciones concretas de ejercicios.
+
+### Entidades
+- `Routine`
+- `RoutineStep`
+- `RoutineBlock`
+- `RoutineTag`
+
+### Notas
+Las rutinas son piezas reutilizables. No deben vivir incrustadas en componentes frontend.
+
+---
+
+## D. Program Engine
+### Responsabilidad
+Construir experiencias de varios días/semanas.
+
+### Entidades
+- `Program`
+- `ProgramDay`
+- `ProgramAssignment`
+- `ProgramMilestone`
+
+### Notas
+El actual challenge de 30 días debería migrar a este contexto.
+
+---
+
+## E. Progress Engine
+### Responsabilidad
+Registrar lo que el usuario realmente hizo.
+
+### Entidades
+- `UserSession`
+- `SessionExerciseLog`
+- `CompletionLog`
+- `Streak`
+- `ProgressMetric`
+- `MilestoneEvent`
+
+### Notas
+Aquí vive la verdad del progreso, no en hacks de UI ni en contadores sueltos.
+
+---
+
+## F. Recommendation Engine
+### Responsabilidad
+Asignar y ajustar programas.
+
+### Entidades
+- `RecommendationProfile`
+- `ProgramRecommendation`
+- `AdaptationRule`
+
+### Notas
+Puede arrancar simple con reglas, no IA.
+
+---
+
+## G. Billing & Access
+### Responsabilidad
+Monetización y control de acceso.
+
+### Entidades
+- `SubscriptionPlan`
+- `Subscription`
+- `Payment`
+- `Entitlement`
+- `PromoCode`
+
+### Notas
+Sin este contexto no hay SaaS real, solo app de contenido.
+
+---
+
+## H. Community (opcional)
+### Responsabilidad
+Capas de engagement no core.
+
+### Entidades
+- `Post`
+- `Comment`
+- `Like`
+- `Leaderboard`
+- `Achievement`
+- `Reward`
+
+### Notas
+Esto debe quedar desacoplado del core premium.
+
+---
+
+## Mapa actual → target
+
+## Conservar con adaptación
+- `profiles`
+- `user_challenges`
+- `daily_progress`
+- `leaderboard`
+- `posts`
+- `post_comments`
+- `post_likes`
+
+## Reinterpretar
+- `user_challenges` → `ProgramAssignment`
+- `daily_progress` → `UserSession` / `CompletionLog`
+- `leaderboard` → módulo opcional de community/gamification
+
+## Crear nuevo
+- `exercises`
+- `exercise_media_assets`
+- `routines`
+- `routine_steps`
+- `programs`
+- `program_days`
+- `user_assessments`
+- `user_programs`
+- `user_sessions`
+- `subscription_plans`
+- `subscriptions`
+- `entitlements`
+
+---
+
+## Decisión estructural
+
+El feed y la gamificación no pueden seguir dictando el dominio.
+El dominio debe ser liderado por:
+- contenido propio
+- rutinas
+- programas
+- progreso
+- suscripción

--- a/.planning/SAAS_MVP_IMPLEMENTATION_PLAN.md
+++ b/.planning/SAAS_MVP_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,164 @@
+# SAAS_MVP_IMPLEMENTATION_PLAN
+
+## Objetivo del MVP
+
+Entregar una primera versión de Pichasafio como SaaS que permita:
+- registro/login
+- onboarding inicial
+- acceso a contenido propio
+- programa guiado
+- rutinas diarias
+- tracking de progreso
+- base lista para monetización premium
+
+---
+
+## Fase 01 - Foundation & Backend
+
+### Entregables
+- backend NestJS creado
+- conexión a Supabase Postgres mediante Prisma
+- auth JWT de Supabase validado en backend
+- estructura modular base
+- contratos API iniciales
+
+### Resultado
+El frontend deja de ser el único lugar donde vive la lógica de negocio.
+
+---
+
+## Fase 02 - Domain & Data Model
+
+### Entregables
+- tablas/modelos nuevas para:
+  - exercises
+  - media_assets
+  - routines
+  - routine_steps
+  - programs
+  - program_days
+  - user_assessments
+  - user_programs
+  - user_sessions
+- estrategia de migración desde `user_challenges` y `daily_progress`
+
+### Resultado
+El contenido y las rutinas pasan a ser sistema reusable.
+
+---
+
+## Fase 03 - Content Admin
+
+### Entregables
+- panel interno o endpoints admin para:
+  - crear ejercicios
+  - subir assets
+  - crear rutinas
+  - crear programas
+  - asignar días y pasos
+
+### Resultado
+Empiezas a producir contenido propio y estructurado.
+
+---
+
+## Fase 04 - User Onboarding & Program Assignment
+
+### Entregables
+- onboarding con:
+  - nivel
+  - objetivo
+  - tiempo disponible
+  - experiencia
+- recomendación simple de programa
+- asignación automática del programa inicial
+
+### Resultado
+La app deja de ser catálogo y se vuelve guiada.
+
+---
+
+## Fase 05 - Daily Routine Experience
+
+### Entregables
+- vista “mi rutina de hoy”
+- pasos de rutina
+- reproducción de media propia
+- marcar sesión como completada
+- feedback y continuidad
+
+### Resultado
+Se activa el loop principal del SaaS.
+
+---
+
+## Fase 06 - Progress & Premium
+
+### Entregables
+- dashboard de progreso
+- streaks y continuidad
+- gating premium
+- planes y entitlements base
+
+### Resultado
+Ya existe núcleo monetizable.
+
+---
+
+## Qué reutilizar del sistema actual
+
+## Reusar
+- auth actual con Supabase
+- perfiles
+- parte de leaderboard/rewards si luego suma al engagement
+- shell frontend y componentes reutilizables
+
+## Refactorizar
+- challengeService
+- progress model actual
+- rutas de rutinas y challenge 30 días
+- acceso directo a Supabase desde cliente para negocio crítico
+
+## Sacar del camino por ahora
+- complejidad social no esencial
+- features accesorias sin impacto en conversión o retención
+
+---
+
+## Prioridad de implementación
+
+1. backend NestJS
+2. modelo de contenido
+3. programa de 30 días reescrito sobre nuevo dominio
+4. progreso y sesiones
+5. monetización
+6. comunidad y gamificación extendida
+
+---
+
+## Primera iteración técnica recomendada
+
+### Sprint 1
+- crear `apps/api`
+- configurar NestJS + Prisma
+- conectar Supabase Postgres
+- validar JWT Supabase
+- exponer `/me`
+- exponer `/programs`
+- exponer `/progress/summary`
+
+### Sprint 2
+- crear modelos `Exercise`, `Routine`, `Program`, `UserProgram`, `UserSession`
+- poblar primer programa oficial de 30 días con contenido propio
+
+### Sprint 3
+- conectar frontend al backend para onboarding, programas y progreso
+
+---
+
+## Meta de negocio del MVP
+
+No es “tener más pantallas”.
+La meta es:
+
+**que un usuario pueda entrar, empezar un programa, volver cada día y tener una razón clara para pagar.**

--- a/.planning/SAAS_REDESIGN.md
+++ b/.planning/SAAS_REDESIGN.md
@@ -1,0 +1,169 @@
+# Pichasafio SaaS Redesign
+
+## Objetivo
+
+Transformar Pichasafio desde una web app de retos y contenido montada principalmente sobre frontend + Supabase hacia una **plataforma SaaS de entrenamiento íntimo guiado**, con:
+
+- contenido propio y reusable
+- rutinas configurables
+- programas premium
+- monetización recurrente
+- backend NestJS como capa de negocio
+- Supabase conservado como infraestructura de datos base
+
+---
+
+## Decisión estratégica principal
+
+La evolución correcta no es seguir agregando videos, retos o gamificación directamente desde el frontend.
+
+La evolución correcta es construir:
+
+**un producto SaaS de contenido modular + rutinas personalizadas + seguimiento + suscripción**
+
+---
+
+## Nuevo posicionamiento del producto
+
+Pichasafio debe dejar de sentirse como:
+- una landing con retos
+- una biblioteca dispersa de ejercicios
+- una app de contenido semi-social
+
+Y pasar a sentirse como:
+- una plataforma guiada de entrenamiento íntimo
+- un sistema de progresión por programas
+- una suscripción con contenido premium propio
+- una experiencia personalizada por objetivo, nivel y constancia
+
+---
+
+## Problemas del estado actual
+
+## Producto
+- el contenido no está modelado como sistema reusable
+- el reto de 30 días está demasiado acoplado a componentes específicos
+- no existe motor fuerte de programas, rutinas y ejercicios
+- hay mezcla de comunidad, feed, retos, rewards y utilidades sin ownership claro
+- la monetización no es el centro del sistema
+
+## Arquitectura
+- mucha lógica crítica vive en frontend
+- Supabase se usa casi como backend directo desde cliente
+- no hay API propia que centralice negocio
+- el modelo actual dificulta reglas premium, recomendaciones y evolución del producto
+- el contenido externo dificulta marca propia y escalabilidad real
+
+---
+
+## Tesis técnica
+
+La mejor arquitectura para la siguiente etapa es:
+
+### Frontend
+- React + Vite actual, evolucionable a app web premium
+
+### Backend
+- **NestJS** como API y capa de negocio
+
+### Datos/Auth/Storage
+- **Supabase** como:
+  - PostgreSQL principal
+  - Auth
+  - Storage
+  - opcionalmente Realtime en algunos módulos
+
+### Regla de arquitectura
+El frontend deja de hablar directamente con la mayor parte de la lógica de negocio en Supabase.
+El frontend pasa a consumir principalmente **NestJS**.
+
+Supabase queda como infraestructura, no como el lugar donde vive toda la aplicación.
+
+---
+
+## Módulos SaaS objetivo
+
+## 1. Identity & Access
+- usuarios
+- perfiles
+- auth vía Supabase
+- sesiones y permisos gestionados por backend
+
+## 2. Content Engine
+- ejercicios
+- variantes
+- instrucciones
+- advertencias
+- assets multimedia
+- categorías
+- objetivos
+- dificultad
+
+## 3. Routine Engine
+- rutinas
+- pasos de rutina
+- calendarios
+- programas
+- días de programa
+- asignación de rutinas al usuario
+
+## 4. Progress Engine
+- sesiones completadas
+- cumplimiento diario
+- streaks
+- milestones
+- progreso histórico
+- adherencia
+
+## 5. Recommendation Engine
+- onboarding
+- objetivo del usuario
+- nivel
+- tiempo disponible
+- sugerencia de programa/rutina
+
+## 6. Billing & Entitlements
+- planes
+- suscripciones
+- acceso premium
+- trial
+- promociones
+- control de acceso por contenido
+
+## 7. Community (opcional / no core MVP)
+- posts
+- comentarios
+- likes
+- leaderboard
+- achievements
+
+---
+
+## Decisión importante de foco
+
+Para construir un SaaS que facture, el orden de prioridad debe ser:
+
+1. contenido propio
+2. programas y rutinas
+3. progreso
+4. suscripción
+5. comunidad y gamificación
+
+Hoy el producto tiene más madura la parte social/gamificada que la parte de contenido/negocio.
+Eso debe invertirse.
+
+---
+
+## Resultado esperado
+
+El usuario debe poder:
+- entrar
+- hacer onboarding
+- recibir un programa recomendado
+- ver su rutina del día
+- consumir contenido propio premium
+- registrar avance
+- mantener continuidad
+- pagar por seguir o desbloquear más programas
+
+Eso es el centro del SaaS.


### PR DESCRIPTION
## Summary
- add foundational SaaS redesign docs for Pichasafio
- define the target domain centered on content, routines, programs, progress and subscriptions
- propose introducing a NestJS backend while keeping Supabase as database/auth/storage
- outline the MVP implementation roadmap to evolve the current app into a monetizable SaaS

## Notes
- this PR is intentionally documentation-first so we can align on product and architecture before touching the current frontend or data model
- next step after approval is creating the NestJS backend foundation and the first implementation phase
